### PR TITLE
test: Fix missing transform ID

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -96,9 +96,10 @@ describe("vite-plugin-strip-comments test", () => {
       );
   });
 
-  it("retains URLs", ()=>{
+  it("retains URLs", () => {
     const plugin = stripComments({ type: "none" });
-    const result = plugin.transform(testSample);
-    expect(result.code, "URLs should have been retained").to.contain(`const response = await fetch("https://github.com/thednp/vite-plugin-strip-comments");`);
+    const result = plugin.transform(testSample, "urls.js");
+    expect(result.code, "URLs should have been retained")
+      .to.contain(`const response = await fetch("https://github.com/thednp/vite-plugin-strip-comments");`);
   })
 });


### PR DESCRIPTION
Seems like I Ctrl+Z'd a bit too much before the commit. If no ID is provided, we don't get the actual transformed code back it seems.

Relates to #1 